### PR TITLE
Fix mobile nav initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,10 +69,11 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById('header').innerHTML = html;
+        initMobileNav();
       })
       .catch(err => console.error('Failed to load header:', err));
   </script>
-  
+
   <!-- Load your main.js after the header is inserted -->
   <script src="main.js"></script>
   

--- a/main.js
+++ b/main.js
@@ -1,19 +1,18 @@
+function initMobileNav() {
+  const hamburger = document.getElementById('hamburger-btn');
+  const mobileMenu = document.getElementById('mobile-menu');
+
+  if (hamburger && mobileMenu) {
+    hamburger.addEventListener('click', () => {
+      mobileMenu.classList.toggle('open');
+    });
+  } else {
+    console.error('Hamburger button or mobile menu not found.');
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  // Because the header is inserted via fetch, delay initialization slightly
-  setTimeout(() => {
-    const hamburger = document.getElementById('hamburger-btn');
-    const mobileMenu = document.getElementById('mobile-menu');
-
-    if (hamburger && mobileMenu) {
-      hamburger.addEventListener('click', () => {
-        mobileMenu.classList.toggle('open');
-      });
-    } else {
-      console.error('Hamburger button or mobile menu not found.');
-    }
-  }, 100); // 100 ms delay to ensure header HTML has loaded
-
-  // Only run carousel on mobile (optional)
+  // Initialize image carousel on mobile screens
   if (window.innerWidth < 768) {
     const imageRow = document.querySelector('.image-row');
     if (imageRow) {
@@ -34,3 +33,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 });
+

--- a/under-construction.html
+++ b/under-construction.html
@@ -18,7 +18,10 @@
   <script>
     fetch('header.html')
       .then(res => res.text())
-      .then(html => { document.getElementById('header').innerHTML = html; })
+      .then(html => {
+        document.getElementById('header').innerHTML = html;
+        initMobileNav();
+      })
       .catch(err => console.error('Failed to load header:', err));
   </script>
   <script src="main.js"></script>


### PR DESCRIPTION
## Summary
- ensure mobile nav event listeners are attached after the header is loaded
- add global `initMobileNav` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68530ec8f5548330a380e006e3550afe