### PR TITLE
Update mobile navigation styling and behaviour

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,13 @@ function initMobileNav() {
     hamburger.addEventListener('click', () => {
       mobileMenu.classList.toggle('open');
     });
+
+    const links = mobileMenu.querySelectorAll('a');
+    links.forEach(link => {
+      link.addEventListener('click', () => {
+        mobileMenu.classList.remove('open');
+      });
+    });
   } else {
     console.error('Hamburger button or mobile menu not found.');
   }

--- a/style.css
+++ b/style.css
@@ -152,36 +152,40 @@ header nav a:hover {
     transform: translateY(-50%);
     z-index: 9999;
   }
-  /* Initially hide the mobile menu */
+  /* Mobile menu covers the full screen */
   .mobile-menu {
-    display: none;
-    position: absolute;  /* If you need absolute positioning */
-    left: 50%;
-    transform: translateX(-50%);
-    flex-direction: column;
-    background-color: #000;
-    padding: 1rem;
-    width: 90%;            /* Or use a fixed width and max-width */
-    max-width: 300px;
-    text-align: left;      /* Left-aligns the text inside the container */
-  }
-  /* When open, display the mobile menu */
-  .mobile-menu.open {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
     display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: #000;
+    transform: translateY(-100%);
+    transition: transform 0.3s ease-in-out;
+    pointer-events: none;
+    text-align: center;
+    font-size: 1.6rem; /* double the original 0.8rem */
+    gap: 1rem; /* doubled spacing between links */
   }
+
+  .mobile-menu.open {
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
   .mobile-menu a {
-    padding: 0.5rem 0;
-    /* Remove borders and default lines */
-    border: none;
-    /* Match the desktop nav typography and color */
+    color: #c8c3b8;
+    text-decoration: none;
     text-transform: uppercase;
-    font-size: 0.8rem;
     font-weight: 700;
     letter-spacing: 0.05em;
     transition: color 0.3s;
-    color: #c8c3b8;
-    text-decoration: none;
   }
+
   .mobile-menu a:hover {
     color: #fff;
   }


### PR DESCRIPTION
## Summary
- tweak mobile menu to fill the viewport and centre items
- enlarge text and spacing in the menu
- animate menu opening/closing and close on link click

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685312b46d888330b460f2ac2bbd0c47