### PR TITLE
Fix mobile header behavior

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -27,6 +27,7 @@
       .then(html => {
         document.getElementById('header').innerHTML = html;
         initMobileNav();
+        initStickyHeader();
       })
       .catch(err => console.error('Failed to load header:', err));
   </script>

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
       .then(html => {
         document.getElementById('header').innerHTML = html;
         initMobileNav();
+        initStickyHeader();
       })
       .catch(err => console.error('Failed to load header:', err));
   </script>

--- a/main.js
+++ b/main.js
@@ -38,6 +38,23 @@ function initMobileCarousel() {
   }
 }
 
+function initStickyHeader() {
+  const header = document.querySelector('header');
+  if (!header) return;
+
+  function checkScroll() {
+    if (window.innerWidth <= 1024 && window.scrollY > 50) {
+      header.classList.add('shrink');
+    } else {
+      header.classList.remove('shrink');
+    }
+  }
+
+  window.addEventListener('scroll', checkScroll);
+  window.addEventListener('resize', checkScroll);
+  checkScroll();
+}
+
 function initProjectFilters() {
   const cards = document.querySelectorAll('.project-card');
   const selects = document.querySelectorAll('.filter-group select');
@@ -73,4 +90,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initMobileNav();
   initMobileCarousel();
   initProjectFilters();
+  initStickyHeader();
 });

--- a/ourwork.html
+++ b/ourwork.html
@@ -17,9 +17,6 @@
       <div id="header"></div>
     </div>
   
-    <div class="main-content">
-    <div id="header"></div>
-
 
 
 
@@ -170,29 +167,23 @@
 
     </section>
 
-
-
-
-
-
-
-    <div id="footer"></div>
-    </div>
+  </div>
 
   <!-- Footer placeholder remains outside -->
   <div id="footer"></div>
 
+  <!-- Load scripts -->
+  <script src="main.js"></script>
   <script>
     fetch('header.html?cb=' + new Date().getTime())
       .then(res => res.text())
       .then(html => {
         document.getElementById('header').innerHTML = html;
+        initMobileNav();
+        initStickyHeader();
       })
       .catch(err => console.error('Failed to load header:', err));
   </script>
-  
-  <!-- Load your main.js after the header is inserted -->
-  <script src="main.js"></script>
   
   <!-- Fetch and insert the footer -->
   <script>

--- a/style.css
+++ b/style.css
@@ -247,6 +247,33 @@ header nav a:hover {
   }
 }
 
+/* Sticky header for mobile and tablet */
+@media (max-width: 1024px) {
+  header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background-color: #000;
+  }
+
+  header.shrink {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+}
+
+@media (max-width: 768px) {
+  header.shrink .logo img {
+    max-height: 35px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1024px) {
+  header.shrink .logo img {
+    max-height: 45px;
+  }
+}
+
 footer {
   background-color: #000;
   color: #fff;


### PR DESCRIPTION
## Summary
- shrink header on scroll for mobile and tablet
- keep header sticky on small screens
- ensure mobile menu initializes after header loads
- clean up `ourwork.html` and ensure dropdown works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5338aa388330a36df7316dce8151