### PR TITLE
Add kitchens grid page

### DIFF
--- a/header.html
+++ b/header.html
@@ -15,7 +15,7 @@
       <!-- Desktop navigation -->
       <nav class="desktop-nav space-x-6 text-sm uppercase font-medium tracking-wide">
         <a href="under-construction.html" class="nav-link">Home</a>
-        <a href="under-construction.html" class="nav-link">Kitchens</a>
+        <a href="kitchens.html" class="nav-link">Kitchens</a>
         <a href="under-construction.html" class="nav-link">Bespoke Interiors</a>
         <a href="ourwork.html" class="nav-link">Our Work</a>
         <a href="under-construction.html" class="nav-link">For Professionals</a>
@@ -27,7 +27,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" class="mobile-menu">
     <a href="under-construction.html" class="mobile-nav-link">Home</a>
-    <a href="under-construction.html" class="mobile-nav-link">Kitchens</a>
+    <a href="kitchens.html" class="mobile-nav-link">Kitchens</a>
     <a href="under-construction.html" class="mobile-nav-link">Bespoke Interiors</a>
     <a href="ourwork.html" class="mobile-nav-link">Our Work</a>
     <a href="under-construction.html" class="mobile-nav-link">For Professionals</a>

--- a/kitchens.html
+++ b/kitchens.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cove Bespoke</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" 
+        integrity="sha512-u+7EGAkzlMXw6s5d5IQ0CxyA1spWVZPP1A5hS+5BnHqA5zNRqM2LIOxp3E2DsvZ+F4B4+7VOE9RSd3TxPoq9dA==" 
+        crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap">
+</head>
+<body>
+  <div class="main-content">
+    <!-- Put your header, hero section, brand section, CTA, etc. here -->
+    <div class="container">
+      <div id="header"></div>
+    </div>
+  
+
+
+
+
+    <!-- Hero ------------------------------------------------------------>
+    <section class="ourwork-hero">
+        <h1>Kitchens</h1>
+        <p class="ourwork-sub">
+        Explore bespoke kitchen projects crafted in a range of styles, materials, and finishes.
+        </p>
+        <hr class="ourwork-divider">
+    </section>
+
+    <!-- Filter bar ------------------------------------------------------>
+    <div class="filter-bar">
+        <div class="filter-group">
+
+        <select>
+            <option selected>Style</option>
+            <option>Contemporary</option>
+            <option>Traditional</option>
+        </select>
+        <select>
+            <option selected>Material</option>
+            <option>Wood</option>
+            <option>Lacquer</option>
+            <option>Laminate</option>
+            <option>Porcelain</option>
+        </select>
+
+        <select>
+            <option selected>Finish</option>
+            <option>Gloss</option>
+            <option>Matte</option>
+            <option>Textured</option>
+        </select>
+        </div>
+
+    </div>
+
+    <!-- Project grid ---------------------------------------------------->
+    <section class="project-grid">
+
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="wood" data-finish="matte">
+            <img src="images\projects\media-wall-display-unit\cover.JPG" alt="Hidden Wine Cellar">
+            <div class="project-info">
+                <h3 class="project-title">Media Wall Display Unit</h3>
+                <p>A bespoke living room installation combining integrated LED-lit glass cabinetry, fireplace, and media wall — finished in matte black for a bold, contemporary focal point.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="wood" data-finish="matte">
+            <img src="images\projects\walnut-winerack\cover.jpg" alt="Hidden Wine Cellar">
+            <div class="project-info">
+                <h3 class="project-title">Hidden Wine Cellar</h3>
+                <p>A discreet under-stair wine feature crafted in anthracite and walnut with angled shelving and soft LED lighting.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="lacquer" data-finish="gloss">
+            <img src="images\projects\gloss-white-kitchen\cover.JPG" alt="Hidden Wine Cellar">
+            <div class="project-info">
+                <h3 class="project-title">Gloss White Kitchen</h3>
+                <p>A sleek handleless kitchen finished in high-gloss white with black glass splashbacks and waterfall quartz island — pairing clean lines with everyday function.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="traditional" data-material="wood" data-finish="matte">
+            <img src="images\projects\classic-shaker-kitchen\cover.JPG" alt="Hidden Wine Cellar">
+            <div class="project-info">
+                <h3 class="project-title">Classic Shaker Kitchen</h3>
+                <p>A timeless shaker-style kitchen with soft sage cabinetry, solid oak worktops, and exposed brick backsplash — blending rural charm with enduring craftsmanship.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="laminate" data-finish="matte">
+            <img src="images\projects\light-grey-handleless-kitchen\cover.JPG" alt="Hidden Wine Cellar">
+            <div class="project-info">
+                <h3 class="project-title">Light Grey Handleless Kitchen</h3>
+                <p>A modern handleless kitchen in light grey with gloss backsplash, built-in ovens, and waterfall island — designed for seamless everyday living with crisp, contemporary lines.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="laminate" data-finish="matte">
+            <img src="images\projects\dark-handleless-kitchen\cover.JPG" alt="Hidden Wine Cellar">
+            <div class="project-info">
+                <h3 class="project-title">Light Grey Handleless Kitchen</h3>
+                <p>A modern handleless kitchen in light grey with gloss backsplash, built-in ovens, and waterfall island — designed for seamless everyday living with crisp, contemporary lines.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="porcelain" data-finish="matte">
+            <img src="images/projects/porcelain-kitchen/cover.PNG" alt="Porcelain Kitchen">
+            <div class="project-info">
+                <h3 class="project-title">Porcelain Kitchen</h3>
+                <p>A refined contemporary kitchen featuring large-format porcelain fronts and matching worktops. Warm wood flooring and soft lighting bring balance to the clean, sculptural design.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="traditional" data-material="wood" data-finish="matte">
+            <img src="images/projects/dark-shaker-wardrobe/cover.JPG" alt="Dark Shaker Wardrobe">
+            <div class="project-info">
+                <h3 class="project-title">Dark Shaker Wardrobe</h3>
+                <p>A built-in shaker wardrobe finished in charcoal oak with solid panelled doors and antique bronze handles — blending period detailing with bold, masculine tones.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="traditional" data-material="wood" data-finish="matte">
+            <img src="images/projects/home-bar-cabinetry/cover.jpg" alt="Home Bar Cabinetry">
+            <div class="project-info">
+                <h3 class="project-title">Home Bar Cabinetry</h3>
+                <p>A tailored home bar setup featuring built-in bottle racks, glass-fronted chillers, and shaker cabinetry with open displays — finished in slate grey with under-lighting and exposed brick backdrop.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+        <!-- Card -->
+        <a href="#" class="project-card static" data-style="contemporary" data-material="porcelain" data-finish="matte">
+            <img src="images/projects/dark-porcelain-kitchen/cover.JPG" alt="Dark Porcelain Kitchen">
+            <div class="project-info">
+                <h3 class="project-title">Dark Porcelain Kitchen</h3>
+                <p>A bold handleless kitchen in dark porcelain with matching splashback and seamless tall units. The large island with integrated breakfast bar anchors this minimalist, modern space.</p>
+            </div>
+            <div class="arrow-icon">→</div>
+        </a>
+
+
+
+    </section>
+
+  </div>
+
+  <!-- Footer placeholder remains outside -->
+  <div id="footer"></div>
+
+  <!-- Load scripts -->
+  <script src="main.js"></script>
+  <script>
+    fetch('header.html?cb=' + new Date().getTime())
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('header').innerHTML = html;
+        initMobileNav();
+        initStickyHeader();
+      })
+      .catch(err => console.error('Failed to load header:', err));
+  </script>
+  
+  <!-- Fetch and insert the footer -->
+  <script>
+    fetch('footer.html?cb=' + new Date().getTime())
+      .then(res => res.text())
+      .then(html => {
+        document.getElementById('footer').innerHTML = html;
+      })
+      .catch(err => console.error('Failed to load footer:', err));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `kitchens.html` page reusing our work grid styling
- allow filtering by style, material, and finish
- update navigation links to point at new Kitchens page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862e8e4b9d083308cd308a7917a2ce3