### PR TITLE
Fix mobile menu overlapping issue

### DIFF
--- a/sections/header/style.css
+++ b/sections/header/style.css
@@ -136,6 +136,7 @@ header nav a:hover {
     justify-content: center;
     align-items: center;
     background-color: #000;
+    z-index: 10000; /* ensure menu appears above all content */
     transform: translateY(-100%);
     transition: transform 0.3s ease-in-out;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- ensure the mobile dropdown menu sits above all page elements

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_6862ebaf8dd88330ad8f5439c53cfbe1