### PR TITLE
Fix cookie banner persistence

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -34,7 +34,10 @@
   <script>
     fetch('footer.html')
       .then(res => res.text())
-      .then(html => { document.getElementById('footer').innerHTML = html; })
+      .then(html => {
+        document.getElementById('footer').innerHTML = html;
+        initCookieBanner();
+      })
       .catch(err => console.error('Failed to load footer:', err));
   </script>
 </body>

--- a/footer.html
+++ b/footer.html
@@ -34,3 +34,9 @@
     <p>&copy; 2025 Cove Bespoke. All rights reserved.</p>
   </div>
 </footer>
+
+<!-- Cookie banner -->
+<div id="cookie-banner">
+  <span>We use cookies to ensure you get the best experience on our website.</span>
+  <button class="cookie-accept">Accept</button>
+</div>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById('footer').innerHTML = html;
+        initCookieBanner();
       })
       .catch(err => console.error('Failed to load footer:', err));
   </script>

--- a/kitchens.html
+++ b/kitchens.html
@@ -189,6 +189,7 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById('footer').innerHTML = html;
+        initCookieBanner();
       })
       .catch(err => console.error('Failed to load footer:', err));
   </script>

--- a/main.js
+++ b/main.js
@@ -86,9 +86,27 @@ function initProjectFilters() {
   });
 }
 
+function initCookieBanner() {
+  const banner = document.getElementById('cookie-banner');
+  if (!banner) return;
+  const acceptBtn = banner.querySelector('.cookie-accept');
+  if (localStorage.getItem('cookieAccepted') === 'true') {
+    banner.style.display = 'none';
+  } else {
+    banner.style.display = 'flex';
+  }
+  if (acceptBtn) {
+    acceptBtn.addEventListener('click', () => {
+      localStorage.setItem('cookieAccepted', 'true');
+      banner.style.display = 'none';
+    });
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initMobileNav();
   initMobileCarousel();
   initProjectFilters();
   initStickyHeader();
+  initCookieBanner();
 });

--- a/ourwork.html
+++ b/ourwork.html
@@ -191,6 +191,7 @@
       .then(res => res.text())
       .then(html => {
         document.getElementById('footer').innerHTML = html;
+        initCookieBanner();
       })
       .catch(err => console.error('Failed to load footer:', err));
   </script>

--- a/sections/cookie-banner/style.css
+++ b/sections/cookie-banner/style.css
@@ -1,0 +1,22 @@
+#cookie-banner {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(0,0,0,0.85);
+  color: #fff;
+  padding: 1rem;
+  z-index: 1000;
+  text-align: center;
+}
+
+#cookie-banner button {
+  margin-left: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #fff;
+  color: #000;
+  border: none;
+  cursor: pointer;
+  font-weight: bold;
+}

--- a/style.css
+++ b/style.css
@@ -7,3 +7,4 @@
 @import url("sections/ourwork/style.css");
 @import url("sections/construction/style.css");
 @import url("sections/coming-soon/style.css");
+@import url("sections/cookie-banner/style.css");

--- a/under-construction.html
+++ b/under-construction.html
@@ -29,7 +29,10 @@
   <script>
     fetch('footer.html')
       .then(res => res.text())
-      .then(html => { document.getElementById('footer').innerHTML = html; })
+      .then(html => {
+        document.getElementById('footer').innerHTML = html;
+        initCookieBanner();
+      })
       .catch(err => console.error('Failed to load footer:', err));
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add new cookie banner styles and markup
- remember cookie consent in localStorage
- show banner from footer fetch across pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643914ec8483309369007db53f4f7e