### PR TITLE
Standardise fonts and colours

### DIFF
--- a/sections/base/style.css
+++ b/sections/base/style.css
@@ -1,10 +1,20 @@
 body {
   background-color: #000;
-  color: #fff;
+  color: #EDEAE3;
   margin: 0;
   padding: 0; /* Removed horizontal padding on the body */
   font-family: sans-serif;
   box-sizing: border-box; /* ensures padding is included in the width calculation */
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Playfair Display', serif;
+  color: #fff;
 }
 
 a,

--- a/sections/brand/style.css
+++ b/sections/brand/style.css
@@ -1,7 +1,7 @@
 /* Brand Section Styles */
 .brand-section {
-  background-color: #1A1A1A;
-  color: #D8D2C6; /* Updated text color */
+  background-color: #000;
+  color: #EDEAE3;
   padding: 4rem 1rem;
 }
 
@@ -27,7 +27,7 @@
 .brand-card p {
   font-family: sans-serif;
   font-weight: 300; /* Soft weight */
-  color: #EAE7E2;  /* Ivory colour */
+  color: #EDEAE3;
 }
 
 /* Widen spacing between the 3 content blocks */

--- a/sections/coming-soon/style.css
+++ b/sections/coming-soon/style.css
@@ -1,6 +1,6 @@
 /* Coming Soon Page Styles */
 .coming-soon-body {
-  background-color: #0E0E0E;
+  background-color: #000;
 }
 
 .coming-soon {
@@ -32,7 +32,7 @@
 .coming-soon p {
   font-family: sans-serif;
   font-size: 1rem;
-  color: #CFC9BD;
+  color: #EDEAE3;
   max-width: 75ch; /* limit width for readability */
   line-height: 1.6;
   margin: 0 auto 2rem;

--- a/sections/construction/style.css
+++ b/sections/construction/style.css
@@ -8,7 +8,7 @@
 
 /* Ensure contact page links are white and underlined */
 .construction a {
-  color: #fff;
+  color: #EDEAE3;
   text-decoration: underline;
 }
 

--- a/sections/cookie-banner/style.css
+++ b/sections/cookie-banner/style.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   background-color: rgba(0,0,0,0.85);
-  color: #fff;
+  color: #EDEAE3;
   padding: 1rem;
   z-index: 1000;
   text-align: center;

--- a/sections/cta-projects/style.css
+++ b/sections/cta-projects/style.css
@@ -19,7 +19,7 @@
 
 .cta-projects p {
   font-size: 1rem;
-  color: #c8c3b8;
+  color: #EDEAE3;
   margin-bottom: 2rem;
 }
 

--- a/sections/footer/style.css
+++ b/sections/footer/style.css
@@ -34,7 +34,7 @@ footer {
   font-weight: 750;
   letter-spacing: 0.05em;
   transition: color 0.3s;
-  color: #c8c3b8;
+  color: #EDEAE3;
   text-decoration: none;
 }
 
@@ -57,7 +57,7 @@ footer {
   font-weight: 750;
   letter-spacing: 0.05em;
   transition: color 0.3s;
-  color: #c8c3b8;
+  color: #EDEAE3;
   text-decoration: none;
 }
 
@@ -74,7 +74,7 @@ footer {
   font-weight: 750;
   letter-spacing: 0.05em;
   transition: color 0.3s;
-  color: #c8c3b8;
+  color: #EDEAE3;
   text-decoration: none;
 }
 
@@ -83,7 +83,7 @@ footer {
 }
 
 .footer-socials a i {
-  color: #c8c3b8;
+  color: #EDEAE3;
   transition: color 0.3s;
 }
 

--- a/sections/header/style.css
+++ b/sections/header/style.css
@@ -54,7 +54,7 @@ header nav a {
   font-weight: 350;
   letter-spacing: 0.05em;
   transition: color 0.3s;
-  color: #c8c3b8;
+  color: #EDEAE3;
   text-decoration: none;
 }
 
@@ -105,7 +105,7 @@ header nav a:hover {
     display: block;
     width: 100%;
     height: 2px;
-    background-color: #c8c3b8; /* match nav link color */
+    background-color: #EDEAE3; /* match nav link color */
   }
 
   .hamburger-btn .line + .line {
@@ -155,7 +155,7 @@ header nav a:hover {
     width: 100%;
     padding: 0 2rem;
     box-sizing: border-box;
-    color: #c8c3b8;
+    color: #EDEAE3;
     text-decoration: none;
     text-transform: uppercase;
     font-weight: 350;
@@ -197,7 +197,7 @@ header nav a:hover {
     display: block;
     width: 100%;
     height: 2px;
-    background-color: #c8c3b8;
+    background-color: #EDEAE3;
   }
 
   .hamburger-btn .line + .line {

--- a/sections/ourwork/style.css
+++ b/sections/ourwork/style.css
@@ -15,7 +15,7 @@
   font-size:1rem;
   letter-spacing:0.15em;
   margin:0.75rem 0 1.5rem;
-  color:#c8c3b8;
+  color:#EDEAE3;
 }
 .ourwork-divider{
   width:3rem;
@@ -27,7 +27,7 @@
 
 /* Filter bar */
 .filter-bar{
-  background:#141414;
+  background:#000;
   display:flex;
   flex-wrap:wrap;
   justify-content:space-between;
@@ -43,8 +43,8 @@
 .filter-bar select,
 .filter-bar input[type="search"]{
   background:transparent;
-  border:1px solid #c8c3b8;
-  color:#c8c3b8;
+  border:1px solid #EDEAE3;
+  color:#EDEAE3;
   padding:0.5rem 2.5rem 0.5rem 0.75rem;
   text-transform:uppercase;
   font-size:0.75rem;
@@ -109,7 +109,7 @@
 
 .project-info p {
   font-size: 0.9rem;
-  color: #c8c3b8;
+  color: #EDEAE3;
   margin: 0.25rem 0 0;
   line-height: 1.4;
   font-family: sans-serif;

--- a/sections/rotating-gallery/style.css
+++ b/sections/rotating-gallery/style.css
@@ -1,6 +1,6 @@
 /* ─── rotating-gallery (inherits Installation-Process layout) ───────────── */
 .rotating-gallery-process {
-  background: #fff;
+  background: #000;
   text-align: center;
   position: relative;
 }
@@ -8,7 +8,7 @@
 
 /* section heading */
 .rotating-gallery-process .section-title{
-  font-family:'Bodoni Moda',serif;
+  font-family:'Playfair Display',serif;
   font-size:clamp(32px,6vw,72px);
   font-weight:400;
   letter-spacing:.08em;
@@ -25,14 +25,14 @@
   margin-bottom:0;
 }
 .process-tabs .tab{
-  font-family:'Work Sans',sans-serif;
+  font-family:sans-serif;
   font-size:14px;
   text-transform:uppercase;
   letter-spacing:1px;
   padding:6px 32px;
   border-radius:40px;
   border:2px solid #003b5c;
-  background:#fff;
+  background:#000;
   color:#003b5c;
   cursor:pointer;
   transition:.3s;
@@ -59,7 +59,7 @@
   height:36px;
   border-radius:50%;
   border:1px solid #ccc;
-  background:#fff;
+  background:#000;
   box-shadow:0 2px 6px rgba(0,0,0,.1);
   display:flex;
   align-items:center;

--- a/sections/rotating-gallery/test/style.css
+++ b/sections/rotating-gallery/test/style.css
@@ -1,6 +1,6 @@
 /* ─── rotating-gallery (inherits Installation-Process layout) ───────────── */
 .rotating-gallery-process {
-  background: #fff;
+  background: #000;
   text-align: center;
   position: relative;
 }
@@ -8,7 +8,7 @@
 
 /* section heading */
 .rotating-gallery-process .section-title{
-  font-family:'Bodoni Moda',serif;
+  font-family:'Playfair Display',serif;
   font-size:clamp(32px,6vw,72px);
   font-weight:400;
   letter-spacing:.08em;
@@ -25,14 +25,14 @@
   margin-bottom:0;
 }
 .process-tabs .tab{
-  font-family:'Work Sans',sans-serif;
+  font-family:sans-serif;
   font-size:14px;
   text-transform:uppercase;
   letter-spacing:1px;
   padding:6px 32px;
   border-radius:40px;
   border:2px solid #003b5c;
-  background:#fff;
+  background:#000;
   color:#003b5c;
   cursor:pointer;
   transition:.3s;
@@ -59,7 +59,7 @@
   height:36px;
   border-radius:50%;
   border:1px solid #ccc;
-  background:#fff;
+  background:#000;
   box-shadow:0 2px 6px rgba(0,0,0,.1);
   display:flex;
   align-items:center;


### PR DESCRIPTION
## Summary
- apply Playfair Display heading style globally
- use off-white text and black backgrounds across sections
- drop Bodoni Moda and Work Sans references

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68650af976a08330b625c15f81dd6855