### PR TITLE
Fix inconsistent header styles

### DIFF
--- a/sections/brand/style.css
+++ b/sections/brand/style.css
@@ -19,6 +19,7 @@
   font-size: 2rem;
   margin-bottom: 1.5rem;
   text-transform: uppercase;
+  color: #fff;
 }
 
 /* Update the subhead and body copy within the brand section */

--- a/sections/cta-projects/style.css
+++ b/sections/cta-projects/style.css
@@ -15,6 +15,7 @@
   font-size: 2rem;
   margin-bottom: 1rem;
   letter-spacing: 0.05em;
+  color: #fff;
 }
 
 .cta-projects p {

--- a/sections/media-scroller/style.css
+++ b/sections/media-scroller/style.css
@@ -3,8 +3,8 @@
 /* Heading */
 .media-scroller .scroller-heading {
   font-family: var(--font-heading);
-  font-size: clamp(32px, 5vw, 60px);
-  color: var(--color-blue);
+  font-size: 2rem;
+  color: #fff;
   margin: 0 1.5rem 3rem;
   text-transform: uppercase;
   text-align: center;                 /* default centre */


### PR DESCRIPTION
## Summary
- align the media scroller heading style with other sections
- ensure `brand` and `cta-projects` sections use the same heading color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68650eca5a9c8330bf9f9e8b19abe095