### PR TITLE
Fix heading sizes

### DIFF
--- a/sections/base/style.css
+++ b/sections/base/style.css
@@ -1,3 +1,9 @@
+:root {
+  --heading-font: 'Playfair Display', serif;
+  --heading-size: 2.5rem;
+  --font-heading: var(--heading-font);
+}
+
 body {
   background-color: #000;
   color: #EDEAE3;
@@ -13,8 +19,13 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: 'Playfair Display', serif;
+  font-family: var(--heading-font);
   color: #fff;
+}
+
+h1,
+h2 {
+  font-size: var(--heading-size);
 }
 
 a,

--- a/sections/brand/style.css
+++ b/sections/brand/style.css
@@ -15,8 +15,7 @@
 
 /* Use a refined serif font for the headline */
 .brand-section h2 {
-  font-family: 'Playfair Display', serif; /* or use 'Cormorant Garamond', serif; */
-  font-size: 2rem;
+  font-size: var(--heading-size);
   margin-bottom: 1.5rem;
   text-transform: uppercase;
   color: #fff;

--- a/sections/intro-banner/style.css
+++ b/sections/intro-banner/style.css
@@ -15,7 +15,7 @@
 .intro-banner__content h1 {
   margin-top: 5vw;
   margin-bottom: 50px;
-  font-size: clamp(36px, 9vw, 100px);
+  font-size: var(--heading-size);
   text-align: center;
 }
 

--- a/sections/media-scroller/style.css
+++ b/sections/media-scroller/style.css
@@ -2,8 +2,8 @@
 
 /* Heading */
 .media-scroller .scroller-heading {
-  font-family: var(--font-heading);
-  font-size: 2rem;
+  font-family: var(--heading-font);
+  font-size: var(--heading-size);
   color: #fff;
   margin: 0 1.5rem 3rem;
   text-transform: uppercase;

--- a/sections/ourwork/style.css
+++ b/sections/ourwork/style.css
@@ -4,14 +4,12 @@
   text-align:center;
 }
 .ourwork-hero h1{
-  font-family:'Playfair Display',serif;
-  font-size:2.5rem;
+  font-size: var(--heading-size);
   letter-spacing:0.2em;
   text-transform:uppercase;
   margin:0;
 }
 .ourwork-sub{
-  font-family:'Playfair Display',serif;
   font-size:1rem;
   letter-spacing:0.15em;
   margin:0.75rem 0 1.5rem;


### PR DESCRIPTION
## Summary
- standardize global heading font and size
- use the global heading style in intro banner, brand, media scroller and ourwork sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686510ca57488330987eec01baf70ae9