### PR TITLE
Remove duplicate top margins on headings

### DIFF
--- a/sections/base/style.css
+++ b/sections/base/style.css
@@ -23,6 +23,7 @@ h5,
 h6 {
   font-family: var(--heading-font);
   color: #fff;
+  margin-top: 0;
 }
 
 /* Base spacing for all sections */

--- a/sections/intro-banner/style.css
+++ b/sections/intro-banner/style.css
@@ -13,7 +13,6 @@
 }
 
 .intro-banner__content h1 {
-  margin-top: 5vw;
   margin-bottom: 50px;
   font-size: var(--heading-size);
   text-align: center;

--- a/sections/media-left/style.css
+++ b/sections/media-left/style.css
@@ -13,7 +13,7 @@
   color: var(--color-blue);
   text-transform: uppercase;
   font-size: clamp(28px, 8vw, 48px);
-  margin: 2rem 1.5rem;
+  margin: 0 1.5rem 2rem;
 }
 
 /* --- Order & spacing -------------------------------------- */
@@ -66,10 +66,10 @@
 
 
 /* ---------- Tablet (768 – 1023 px) ---------- */
-@media (min-width: 768px) and (max-width: 1023px) {
+  @media (min-width: 768px) and (max-width: 1023px) {
   .media-left__heading {
     font-size: clamp(32px, 6vw, 56px);
-    margin: 4rem 2rem 2.5rem;
+    margin: 0 2rem 2.5rem;
   }
 
   .media-left__content {
@@ -89,7 +89,7 @@
 }
 
 /* ------------- DESKTOP (≥ 1024 px) --------------------- */
-@media (min-width: 1024px) {
+  @media (min-width: 1024px) {
   .media-left__wrapper {
     flex-direction: row;
     align-items: stretch;
@@ -120,7 +120,7 @@
 
   .media-left__heading {
     font-size: clamp(40px, 4vw, 64px);
-    margin: 6rem 0 3rem;
+    margin: 0 0 3rem;
     text-align: center;
   }
 


### PR DESCRIPTION
## Summary
- drop extra top margin from `.intro-banner` heading
- keep only bottom margins on `.media-left__heading`
- set all headings to have zero top margin

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6865248f06688330935bf4505f3cb842