### PR TITLE
Fix Kitchens link to under-construction page

### DIFF
--- a/header.html
+++ b/header.html
@@ -15,7 +15,7 @@
       <!-- Desktop navigation -->
       <nav class="desktop-nav space-x-6 text-sm uppercase font-medium tracking-wide">
         <a href="index.html" class="nav-link">Home</a>
-        <a href="kitchens.html" class="nav-link">Kitchens</a>
+        <a href="under-construction.html" class="nav-link">Kitchens</a>
         <a href="under-construction.html" class="nav-link">Bespoke Interiors</a>
         <a href="ourwork.html" class="nav-link">Our Work</a>
         <a href="trade.html" class="nav-link">For Professionals</a>
@@ -27,7 +27,7 @@
   <!-- Mobile menu -->
   <nav id="mobile-menu" class="mobile-menu">
     <a href="under-construction.html" class="mobile-nav-link">Home</a>
-    <a href="kitchens.html" class="mobile-nav-link">Kitchens</a>
+    <a href="under-construction.html" class="mobile-nav-link">Kitchens</a>
     <a href="under-construction.html" class="mobile-nav-link">Bespoke Interiors</a>
     <a href="ourwork.html" class="mobile-nav-link">Our Work</a>
     <a href="trade.html" class="mobile-nav-link">For Professionals</a>


### PR DESCRIPTION
## Summary
- update navigation links so Kitchens points to the under‑construction page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68652fd886508330b566aa0bb92ba47f