### PR TITLE
Remove rotating gallery pills

### DIFF
--- a/projects-classic-shaker-kitchen.html
+++ b/projects-classic-shaker-kitchen.html
@@ -17,14 +17,6 @@
       <h2 class="section-title">Classic Shaker Kitchen</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-dark-handleless-kitchen.html
+++ b/projects-dark-handleless-kitchen.html
@@ -17,13 +17,6 @@
       <h2 class="section-title">Dark Handleless Kitchen</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-dark-porcelain-kitchen.html
+++ b/projects-dark-porcelain-kitchen.html
@@ -17,16 +17,6 @@
       <h2 class="section-title">Dark Porcelain Kitchen</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="3">4</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="4">5</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-dark-shaker-wardrobe.html
+++ b/projects-dark-shaker-wardrobe.html
@@ -17,14 +17,6 @@
       <h2 class="section-title">Dark Shaker Wardrobe</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-gloss-white-kitchen.html
+++ b/projects-gloss-white-kitchen.html
@@ -17,16 +17,6 @@
       <h2 class="section-title">Gloss White Kitchen</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="3">4</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="4">5</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-home-bar-cabinetry.html
+++ b/projects-home-bar-cabinetry.html
@@ -17,12 +17,6 @@
       <h2 class="section-title">Home Bar Cabinetry</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-light-grey-handleless-kitchen.html
+++ b/projects-light-grey-handleless-kitchen.html
@@ -17,17 +17,6 @@
       <h2 class="section-title">Light Grey Handleless Kitchen</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="3">4</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="4">5</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="5">6</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-media-wall-display-unit.html
+++ b/projects-media-wall-display-unit.html
@@ -17,18 +17,6 @@
       <h2 class="section-title">Media Wall Display Unit</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-            <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="3">4</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="4">5</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="5">6</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="6">7</button></div>
-            <div class="swiper-slide"><button class="tab" data-slide="7">8</button></div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-porcelain-kitchen.html
+++ b/projects-porcelain-kitchen.html
@@ -17,13 +17,6 @@
       <h2 class="section-title">Porcelain Kitchen</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/projects-walnut-winerack.html
+++ b/projects-walnut-winerack.html
@@ -17,18 +17,6 @@
       <h2 class="section-title">Hidden Wine Cellar</h2>
       <div class="process-tabs-wrapper">
         <div class="swiper-button-prev"></div>
-        <div class="tabs-swiper swiper process-tabs">
-          <div class="swiper-wrapper">
-              <div class="swiper-slide"><button class="tab active" data-slide="0">1</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="1">2</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="2">3</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="3">4</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="4">5</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="5">6</button></div>
-              <div class="swiper-slide"><button class="tab" data-slide="6">7</button></div>
-            </div>
-          </div>
-        </div>
         <div class="swiper-button-next"></div>
       </div>
 

--- a/sections/rotating-gallery/script.js
+++ b/sections/rotating-gallery/script.js
@@ -8,10 +8,10 @@
   if (!section) return;
 
   const pillsEl   = section.querySelector('.tabs-swiper');
-  const trackEl   = pillsEl.querySelector('.swiper-wrapper');
-  const originals = [...trackEl.querySelectorAll('.swiper-slide')];
+  const trackEl   = pillsEl?.querySelector('.swiper-wrapper');
+  const originals = trackEl ? [...trackEl.querySelectorAll('.swiper-slide')] : [];
   const texts     = [...section.querySelectorAll('.process-text')];
-  const total     = originals.length;
+  const total     = section.querySelectorAll('.rotating-gallery-swiper .swiper-slide').length;
   let activeIndex = 0;
 
   /* --- image carousel --- */
@@ -57,7 +57,7 @@
   /* --- helpers --- */
   function setActive(i) {
     activeIndex = i;
-    trackEl.querySelectorAll('.tab')
+    trackEl?.querySelectorAll('.tab')
            .forEach(btn => btn.classList.toggle('active', +btn.dataset.slide === i));
     texts.forEach(t => t.classList.toggle('active', +t.dataset.step === i));
   }
@@ -66,12 +66,13 @@
     tab.addEventListener('click', () => {
       const i = +tab.dataset.slide;
       gallerySwiper.slideToLoop(i);
-      buildPills(i);
+      if (trackEl) buildPills(i);
       setActive(i);
     });
   }
 
   function buildPills(center) {
+    if (!trackEl) return;
     trackEl.innerHTML = '';
     const visible = 20;
     const half    = Math.floor(visible / 2);
@@ -87,21 +88,21 @@
   function move(dir) {
     let next = dir === 'next' ? activeIndex + 1 : activeIndex - 1;
     next = (next + total) % total;
-    buildPills(next);
+    if (trackEl) buildPills(next);
     setActive(next);
   }
 
   /* --- bindings --- */
   gallerySwiper.on('slideChangeTransitionEnd', () => {
     const i = gallerySwiper.realIndex;
-    buildPills(i);
+    if (trackEl) buildPills(i);
     setActive(i);
   });
 
   section.querySelector('.swiper-button-next')?.addEventListener('click', () => move('next'));
   section.querySelector('.swiper-button-prev')?.addEventListener('click', () => move('prev'));
 
-  buildPills(0);          /* initialise */
+  if (trackEl) buildPills(0);          /* initialise */
   setActive(0);
   updateScale();
 })();

--- a/sections/rotating-gallery/test/script.js
+++ b/sections/rotating-gallery/test/script.js
@@ -8,8 +8,11 @@
   if (!section) return;
 
   const pillsEl   = section.querySelector('.tabs-swiper');
+  const trackEl   = pillsEl?.querySelector('.swiper-wrapper');
+  const originals = trackEl ? [...trackEl.querySelectorAll('.swiper-slide')] : [];
   const texts     = [...section.querySelectorAll('.process-text')];
-  const totalPills = pillsEl.querySelectorAll('.swiper-slide').length;
+  const total     = section.querySelectorAll('.rotating-gallery-swiper .swiper-slide').length;
+  let activeIndex = 0;
 
   /* --- image carousel --- */
   const gallerySwiper = new Swiper(
@@ -51,58 +54,56 @@
     });
   });
 
-  /* --- pill carousel --- */
-
-  const pillsSwiper = new Swiper(pillsEl, {
-    slidesPerView: 'auto',
-    centeredSlides: true,
-    spaceBetween: 16,
-    loop: true,
-    loopAdditionalSlides: totalPills,
-  });
-
+  /* --- helpers --- */
   function setActive(i) {
-    pillsEl.querySelectorAll('.tab').forEach(btn => btn.classList.remove('active'));
-    pillsSwiper.slides[pillsSwiper.activeIndex]
-              ?.querySelector('.tab')
-              ?.classList.add('active');
+    activeIndex = i;
+    trackEl?.querySelectorAll('.tab')
+           .forEach(btn => btn.classList.toggle('active', +btn.dataset.slide === i));
     texts.forEach(t => t.classList.toggle('active', +t.dataset.step === i));
   }
 
-  pillsEl.querySelectorAll('.tab').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const i = +btn.dataset.slide;
+  function addTabClick(tab) {
+    tab.addEventListener('click', () => {
+      const i = +tab.dataset.slide;
       gallerySwiper.slideToLoop(i);
-      pillsSwiper.slideToLoop(i);
+      if (trackEl) buildPills(i);
+      setActive(i);
     });
+  }
+
+  function buildPills(center) {
+    if (!trackEl) return;
+    trackEl.innerHTML = '';
+    const visible = 20;
+    const half    = Math.floor(visible / 2);
+    for (let off = -half; off <= half; off++) {
+      const i = (center + off + total) % total;
+      const clone = originals[i].cloneNode(true);
+      addTabClick(clone.querySelector('.tab'));
+      trackEl.appendChild(clone);
+    }
+    updateScale();
+  }
+
+  function move(dir) {
+    let next = dir === 'next' ? activeIndex + 1 : activeIndex - 1;
+    next = (next + total) % total;
+    if (trackEl) buildPills(next);
+    setActive(next);
+  }
+
+  /* --- bindings --- */
+  gallerySwiper.on('slideChangeTransitionEnd', () => {
+    const i = gallerySwiper.realIndex;
+    if (trackEl) buildPills(i);
+    setActive(i);
   });
 
-  /* --- sync swipers --- */
-  let syncing = false;
+  section.querySelector('.swiper-button-next')?.addEventListener('click', () => move('next'));
+  section.querySelector('.swiper-button-prev')?.addEventListener('click', () => move('prev'));
 
-  function syncFromGallery() {
-    if (syncing) return;
-    syncing = true;
-    const i = gallerySwiper.realIndex;
-    pillsSwiper.slideToLoop(i);
-    setActive(i);
-    syncing = false;
-  }
-
-  function syncFromPills() {
-    if (syncing) return;
-    syncing = true;
-    const i = pillsSwiper.realIndex;
-    gallerySwiper.slideToLoop(i);
-    // ensure the active pill is centred after dragging
-    pillsSwiper.slideToLoop(i);
-    setActive(i);
-    syncing = false;
-  }
-
-  gallerySwiper.on('slideChangeTransitionEnd', syncFromGallery);
-  pillsSwiper.on('slideChangeTransitionEnd', syncFromPills);
-
+  if (trackEl) buildPills(0);          /* initialise */
+  setActive(0);
   updateScale();
-  syncFromGallery();
 })();
+

--- a/sections/rotating-gallery/test/test.html
+++ b/sections/rotating-gallery/test/test.html
@@ -31,21 +31,6 @@
 
     <div class="process-tabs-wrapper">
       <div class="swiper-button-prev"></div>
-      <div class="tabs-swiper swiper process-tabs">
-        <div class="swiper-wrapper">
-          <div class="swiper-slide"><button class="tab active" data-slide="0">Wall Cladding</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="1">Flooring</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="2">Kitchen Worktops</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="3">Furnishing Elements</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="4">Exterior Façade</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="5">Washbasins & Vanities</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="6">Shower Trays</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="7">Stair Treads</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="8">Cabinet Fronts</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="9">Fireplace Surrounds</button></div>
-          <div class="swiper-slide"><button class="tab" data-slide="10">Tables</button></div>
-        </div>
-      </div>
       <div class="swiper-button-next"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- remove tabs-swiper markup from all project pages
- update rotating gallery script to gracefully handle missing tabs
- remove pill markup from gallery test and sync test script

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68652fcba6188330b322c1ce14cd84b4